### PR TITLE
scripts: intermediate-generator: align expiry

### DIFF
--- a/scripts/intermediate-generator.sh
+++ b/scripts/intermediate-generator.sh
@@ -73,7 +73,7 @@ parse_params() {
 	a_unit=''
 	config=''
 	data_dir=''
-	expiry=7300
+	expiry=3650
 	force=0
 	ia_pw="${SIMPLE_CA_INTERMEDIATE_PASSWORD-}"
 	openssl=$(which openssl)


### PR DESCRIPTION
set default to 3650 as described in usage()

resolves #2 